### PR TITLE
new version module directory 0.1.x. correct path concat.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "redis": ">= 0.7.1"
   },
   "dependencies" : {
-    "directory": "0.0.x", 
+    "directory": "0.1.x",
     "mongoose": "~3.5.8"
   },
   "devDependencies" : {


### PR DESCRIPTION
Использование path join в mongoose-troop/index.js для соединения пути привело к несовместимости с версией модуля directory (0.0.10). В этой версии в нем не учитывается что путь может не заканчиваться на символ "/" из-за чего имя файла модулей mongoose парсится не верно.
Данная ошибка проявляется при запуске javascript-nodejs в ubuntu (скорее всего и на mac). Новая версия модуля directory 0.1.0 написана более корректно и обрабатывает эту ситуацию.
